### PR TITLE
task-07 (https://github.com/rolling-scopes-school/nodejs-aws-tasks/bl…

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -31,12 +31,16 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
   };
 
   const uploadFile = async (e: any) => {
+      const authorization_token = localStorage.getItem('authorization_token');
       // Get the presigned URL
       const response = await axios({
         method: 'GET',
         url,
         params: {
           name: encodeURIComponent(file.name)
+        },
+        headers: {
+          Authorization: `Basic ${authorization_token}`
         }
       })
       console.log('File to upload: ', file.name)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,9 @@ axios.interceptors.response.use(
     if (error.response.status === 400) {
       alert(error.response.data?.data);
     }
+    if (error.response.status === 401 || error.response.status === 403) {
+      alert(error.response.data?.message);
+    }
     return Promise.reject(error.response);
   }
 );


### PR DESCRIPTION
# [Task 07](https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task7-lambda%2Bcognito-authorization/task.md)
[Lecture](https://www.youtube.com/watch?v=cWsNF3kmDuE&t=626s&ab_channel=RollingScopesSchool) | [QA](https://youtu.be/GFPKFMFAV6o)

Link to FE Application: https://d1bf2hwgu6wjxf.cloudfront.net
Link to BE PR: https://github.com/bhondu/nodejs-aws-be/pull/5

What was done? 

5. - [x] update client application to send `Authorization: Basic authorization_token` header on import. Client should get `authorization_token` value from browser localStorage.

Additional (optional) tasks

1. - [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. 
